### PR TITLE
Fix economic index

### DIFF
--- a/scripts/evaluate_submission.py
+++ b/scripts/evaluate_submission.py
@@ -186,6 +186,8 @@ def compute_metrics(
 
     # Fetch all the desired outputs to compute various metrics.
     desired_outputs = list(_METRICS_TO_LABEL_DICT.keys())
+    # Add auxiliary outputs required for processing
+    required_outputs = desired_outputs + ["activity_timestep"]
 
     episode_states = {}
     eval_metrics = {}
@@ -193,11 +195,11 @@ def compute_metrics(
         for episode_id in range(num_episodes):
             if fetch_episode_states is not None:
                 episode_states[episode_id] = fetch_episode_states(
-                    trainer, desired_outputs
+                    trainer, required_outputs 
                 )
             else:
                 episode_states[episode_id] = trainer.fetch_episode_global_states(
-                    desired_outputs
+                    required_outputs
                 )
 
         for feature in desired_outputs:
@@ -216,6 +218,14 @@ def compute_metrics(
                     feature_values[episode_id] = episode_states[episode_id][feature][
                         -1, 0
                     ]
+
+            elif feature == "gross_output_all_regions":
+                for episode_id in range(num_episodes):
+                    # collect gross output results based on activity timestep
+                    activity_timestep = episode_states[episode_id]["activity_timestep"]
+                    activity_index = np.append(1.0, np.diff(activity_timestep.squeeze()))
+                    activity_index = [np.isclose(v, 1.0) for v in activity_index]
+                    feature_values[episode_id] = np.sum(episode_states[episode_id]["gross_output_all_regions"][activity_index])
 
             else:
                 for episode_id in range(num_episodes):

--- a/scripts/evaluate_submission.py
+++ b/scripts/evaluate_submission.py
@@ -26,6 +26,7 @@ from pathlib import Path
 _path = Path(os.path.abspath(__file__))
 
 from fixed_paths import PUBLIC_REPO_DIR
+from run_unittests import fetch_base_env
 from gym.spaces import MultiDiscrete
 
 # climate-cooperation-competition
@@ -117,39 +118,6 @@ def get_results_dir():
         return results_dir, parser
     except Exception as err:
         raise ValueError("Cannot obtain the results directory") from err
-
-
-def fetch_base_env(base_folder=".tmp/_base"):
-    """
-    Download the base version of the code from GitHub.
-    """
-    if not base_folder.startswith('/'):
-      base_folder = os.path.join(PUBLIC_REPO_DIR, base_folder)
-      #print(f"Using tmp dir {base_folder}")
-    if os.path.exists(base_folder):
-        shutil.rmtree(base_folder)
-    os.makedirs(base_folder, exist_ok=False)
-
-    print(
-        "\nDownloading a base version of the code from GitHub"
-        " to run consistency checks..."
-    )
-    prev_dir = os.getcwd()
-    os.chdir(base_folder)
-    subprocess.call(["wget", "-O", "rice.py", _BASE_RICE_PATH])
-    subprocess.call(["wget", "-O", "rice_helpers.py", _BASE_RICE_HELPERS_PATH])
-    if "region_yamls" not in os.listdir(base_folder):
-        shutil.copytree(
-            os.path.join(PUBLIC_REPO_DIR, "region_yamls"),
-            os.path.join(base_folder, "region_yamls"),
-        )
-
-    base_rice = import_class_from_path("Rice", os.path.join(base_folder, "rice.py"))()
-
-    # Clean up base code
-    os.chdir(prev_dir)
-    shutil.rmtree(base_folder)
-    return base_rice
 
 
 def validate_dir(results_dir=None):

--- a/scripts/run_unittests.py
+++ b/scripts/run_unittests.py
@@ -8,16 +8,17 @@
 """
 Unit tests for the rice simulation
 """
+import argparse
 import importlib.util as iu
 import logging
 import os
 import shutil
 import subprocess
 import sys
+import time
 import unittest
 
 import numpy as np
-from evaluate_submission import get_results_dir
 
 from fixed_paths import PUBLIC_REPO_DIR
 sys.path.append(PUBLIC_REPO_DIR)
@@ -263,6 +264,43 @@ class TestEnv(unittest.TestCase):
             subprocess.check_output(
                 ["python", "scripts/run_cpu_gpu_env_consistency_checks.py"]
             )
+
+
+def get_results_dir():
+    """
+    Obtain the 'results' directory from the system arguments.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--results_dir",
+        "-r",
+        type=str,
+        default=".",
+        help="the directory where all the submission files are saved. Can also be "
+        "the zipped file containing all the submission files.",
+    )
+    args = parser.parse_args()
+
+    if "results_dir" not in args:
+        raise ValueError(
+            "Please provide a results directory to evaluate with the argument -r"
+        )
+    if not os.path.exists(args.results_dir):
+        raise ValueError(
+            "The results directory is missing. Please make sure the correct path "
+            "is specified!"
+        )
+    try:
+        results_dir = args.results_dir
+
+        # Also handle a zipped file
+        if results_dir.endswith(".zip"):
+            unzipped_results_dir = os.path.join("/tmp", str(time.time()))
+            shutil.unpack_archive(results_dir, unzipped_results_dir)
+            results_dir = unzipped_results_dir
+        return results_dir, parser
+    except Exception as err:
+        raise ValueError("Cannot obtain the results directory") from err
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We fixed the issue that caused the economic index to be too high because of the additional negotiation steps. It is a quick fix that collects only the relevant gross output values in the `compute_metrics` method, based on the `activity_timestep` value. This value is logged in RICE and only increases when an actual RICE simulation step is performed. We use this as a trigger to collect the relevant results. This way it should also be robust against a variable number of negotiation steps.