### PR TITLE
Consistently use env.num_agents

### DIFF
--- a/scripts/train_with_rllib.py
+++ b/scripts/train_with_rllib.py
@@ -339,7 +339,7 @@ def fetch_episode_states(trainer_obj=None, episode_states=None):
     agent_states = {}
     policy_ids = {}
     policy_mapping_fn = trainer_obj.config["multiagent"]["policy_mapping_fn"]
-    for region_id in range(env.num_regions):
+    for region_id in range(env.num_agents):
         policy_ids[region_id] = policy_mapping_fn(region_id)
         agent_states[region_id] = trainer_obj.get_policy(
             policy_ids[region_id]


### PR DESCRIPTION
I noticed in `train_with_rllib.py` that `env.num_regions` is used in some cases (line 342) and `env.num_agents` is used in others (line 355). I changed line 342 to also use `env.num_agents`, which allows the possibility of creating non-region agents to run in the simulation.