### PR TITLE
Upgrade to Ray 2.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ tensorflow==1.13.1
 torch==1.9.0
 # optional: RLlib and WarpDrive for training
 # For CPU
-# ray[rllib]==1.0.0 
+ray[rllib]==2.7.1
 # For GPU
 # rl-warp-drive==1.7.0
 matplotlib==3.5.3

--- a/scripts/train_with_rllib.py
+++ b/scripts/train_with_rllib.py
@@ -18,10 +18,17 @@ import sys
 import time
 
 import numpy as np
+import ray
+import torch
 import yaml
 from desired_outputs import desired_outputs
 from fixed_paths import PUBLIC_REPO_DIR
+from gym.spaces import Box, Dict
+from ray.rllib.algorithms.a2c import A2C
+from ray.rllib.env.multi_agent_env import MultiAgentEnv
 from run_unittests import import_class_from_path
+from torch_models import TorchLinear
+
 from opt_helper import save
 from rice import Rice
 
@@ -29,43 +36,6 @@ sys.path.append(PUBLIC_REPO_DIR)
 
 # Set logger level e.g., DEBUG, INFO, WARNING, ERROR.
 logging.getLogger().setLevel(logging.DEBUG)
-
-
-def perform_other_imports():
-    """
-    RLlib-related imports.
-    """
-    import ray
-    import torch
-    from gym.spaces import Box, Dict
-    from ray.rllib.agents.a3c import A2CTrainer
-    from ray.rllib.env.multi_agent_env import MultiAgentEnv
-    from ray.tune.logger import NoopLogger
-
-    return ray, torch, Box, Dict, MultiAgentEnv, A2CTrainer, NoopLogger
-
-
-print("Do imports")
-
-try:
-    other_imports = perform_other_imports()
-except ImportError:
-    print("Installing requirements...")
-
-    # Install gym
-    subprocess.call(["pip", "install", "gym==0.21.0"])
-    # Install RLlib v1.0.0
-    subprocess.call(["pip", "install", "ray[rllib]==1.0.0"])
-    # Install PyTorch
-    subprocess.call(["pip", "install", "torch==1.9.0"])
-
-    other_imports = perform_other_imports()
-
-ray, torch, Box, Dict, MultiAgentEnv, A2CTrainer, NoopLogger = other_imports
-
-from torch_models import TorchLinear
-
-logging.info("Finished imports")
 
 
 _BIG_NUMBER = 1e20

--- a/scripts/train_with_rllib.py
+++ b/scripts/train_with_rllib.py
@@ -210,6 +210,7 @@ def get_rllib_config(exp_run_config=None, env_class=None, seed=None):
         if train_config["num_workers"] > 0
         else train_config["num_envs"],
         "train_batch_size": train_config["train_batch_size"],
+        "disable_env_checking": True,
     }
     if seed is not None:
         rllib_config["seed"] = seed

--- a/scripts/train_with_rllib.py
+++ b/scripts/train_with_rllib.py
@@ -298,7 +298,7 @@ def create_trainer(
 
     # Create the A2C trainer.
     exp_run_config["env"]["source_dir"] = source_dir
-    rllib_trainer = A2CTrainer(
+    rllib_trainer = A2C(
         env=EnvWrapper,
         config=get_rllib_config(
             exp_run_config=exp_run_config, env_class=EnvWrapper, seed=seed

--- a/scripts/train_with_rllib.py
+++ b/scripts/train_with_rllib.py
@@ -181,8 +181,7 @@ def get_rllib_config(exp_run_config=None, env_class=None, seed=None):
     }
 
     # Function mapping agent ids to policy ids.
-    def policy_mapping_fn(agent_id=None):
-        assert agent_id is not None
+    def policy_mapping_fn(agent_id, episode, worker, **kwargs):
         return "regions"
 
     # Optional list of policies to train, or None for all policies.

--- a/scripts/train_with_rllib.py
+++ b/scripts/train_with_rllib.py
@@ -528,7 +528,7 @@ if __name__ == "__main__":
     num_episodes = trainer_config["num_episodes"]
     train_batch_size = trainer_config["train_batch_size"]
     # Fetch the env object from the trainer
-    env_obj = trainer.workers.local_worker().env.env
+    env_obj = trainer.workers.local_worker().env.env.env
     episode_length = env_obj.episode_length
     num_iters = (num_episodes * episode_length) // train_batch_size
 


### PR DESCRIPTION
Upgrade Ray to version 2.7.1.

Some things to consider:
- Ray uses an additional compatibility class layer to deal with the old-style environment. Ray moved to Gymnasium instead of Gym as Gym is discontinued.
- Disabled environment checking by Ray due to a compatibility class. The environment checker caused quite some issues with the old-style environment. It would be better to reimplement the environment properly.
- Usage of the A2C trainer is also deprecated and will cause an error with future Ray versions. For now, it does work, but it would be better to move to the  new standard:
```python
config = A2CConfig()
algo = config.build()
algo.train()
```