### PR TITLE
Scenarios

### DIFF
--- a/rice.py
+++ b/rice.py
@@ -35,7 +35,8 @@ class Rice(gym.Env):
     def __init__(
         self,
         num_discrete_action_levels=10,  # the number of discrete levels for actions, > 1
-        negotiation_on=False,  # If True then negotiation is on, else off
+        negotiation_on=False,
+        scenario="default"  # If True then negotiation is on, else off
     ):
         self.global_state = {}
 

--- a/scenarios.py
+++ b/scenarios.py
@@ -1,0 +1,136 @@
+from rice import *
+
+class OptimalMitigation(Rice):
+
+    """Scenario where all agents mitigate to a given extent
+    
+        Arguments:
+        - num_discrete_action_levels (int):  the number of discrete levels for actions, > 1
+        - negotiation_on (boolean): whether negotiation actions are available to agents
+        - scenario (str): name of scenario 
+    
+        Attributes:
+        - maximum_mitigation_rate: the rate rate all agents will mitigate to.
+        """
+    
+
+    def __init__(self,
+                 num_discrete_action_levels=10,  # the number of discrete levels for actions, > 1
+                 negotiation_on=False, # If True then negotiation is on, else off
+                 scenario="OptimalMitigation"  
+            ):
+        super().__init__(num_discrete_action_levels,negotiation_on,scenario)
+        self.maximum_mitigation_rate = 9
+
+    def calc_action_mask(self):
+        """
+        Generate action masks.
+        """
+        mask_dict = {region_id: None for region_id in range(self.num_regions)}
+        for region_id in range(self.num_regions):
+            mask = self.default_agent_action_mask.copy()
+
+            mitigation_mask = np.array(
+                    [0 for _ in range(self.maximum_mitigation_rate)]
+                    + [
+                        1
+                        for _ in range(
+                            self.num_discrete_action_levels
+                            - self.maximum_mitigation_rate
+                        )
+                    ]
+                )
+
+            mask_start = sum(self.savings_possible_actions)
+            mask_end = mask_start + sum(
+                    self.mitigation_rate_possible_actions
+                )
+            mask[mask_start:mask_end] = mitigation_mask
+            mask_dict[region_id] = mask
+
+        return mask_dict
+    
+class BasicClub(Rice):
+
+    """Scenario where a subset of regions mitigate to a set amount, 
+        other agents get a tariff based on the difference between their mitigation rate
+        and the club rate
+    
+        Arguments:
+        - num_discrete_action_levels (int):  the number of discrete levels for actions, > 1
+        - negotiation_on (boolean): whether negotiation actions are available to agents
+        - scenario (str): name of scenario 
+    
+        Attributes:
+        - club_mitigation_rate: the rate rate all agents will mitigate to.
+        - club_members: subset of states in club
+        """
+    
+
+    def __init__(self,
+                 num_discrete_action_levels=10,  # the number of discrete levels for actions, > 1
+                 negotiation_on=False, # If True then negotiation is on, else off
+                 scenario="BasicClub"  
+            ):
+        super().__init__(num_discrete_action_levels,negotiation_on,scenario)
+        self.club_mitigation_rate = 9
+        #Note: this will be updated later with more targeted region_ids
+        self.club_members = [1,2,3,4,15,8,12]
+
+    def calc_action_mask(self):
+        """
+        Generate action masks.
+        """
+        mask_dict = {region_id: None for region_id in range(self.num_regions)}
+        for region_id in range(self.num_regions):
+
+            mask = self.default_agent_action_mask.copy()
+
+            #club members mitigate
+            if region_id in self.club_members:
+                mask = self.default_agent_action_mask.copy()
+                #mask mitigation
+                mitigation_mask = np.array(
+                        [0 for _ in range(self.club_mitigation_rate)]
+                        + [
+                            1
+                            for _ in range(
+                                self.num_discrete_action_levels
+                                - self.club_mitigation_rate
+                            )
+                        ]
+                    )
+
+                mitigation_mask_start = sum(self.savings_possible_actions)
+                mitigation_mask_end = mitigation_mask_start + sum(
+                        self.mitigation_rate_possible_actions
+                    )
+                mask[mitigation_mask_start:mitigation_mask_end] = mitigation_mask
+                
+                #tariff non club members
+                tariff_mask = []
+                for other_region_id in range(self.num_regions):
+                    # if other region is self or in club
+                    if (other_region_id == region_id) or (other_region_id in self.club_members):
+                        # minimize tariff for free trade
+                        regional_tariff_mask = [1] + [0] * (self.num_discrete_action_levels-1)
+                    else:
+                        other_region_mitigation_rate = self.get_state("mitigation_rates_all_regions",
+                                                                       region_id=other_region_id)
+                        #min tariff by difference between mitigation rate and club mitigation rate
+                        tariff_rate = int(self.club_mitigation_rate - other_region_mitigation_rate)
+                        regional_tariff_mask = [0] * tariff_rate \
+                            + [1] * (self.num_discrete_action_levels-tariff_rate)
+                    tariff_mask.extend(regional_tariff_mask)
+
+                #mask tariff
+                tariffs_mask_start = self.get_actions_index("import_tariffs")
+                tariff_mask_end = self.num_regions * self.num_discrete_action_levels + tariffs_mask_start
+                mask[tariffs_mask_start:tariff_mask_end] = np.array(tariff_mask)
+
+
+            mask_dict[region_id] = mask
+            
+        return mask_dict
+    
+

--- a/scripts/rice_rllib.yaml
+++ b/scripts/rice_rllib.yaml
@@ -24,6 +24,7 @@ trainer:
     # === Hardware Settings ===
     num_workers: 0 # number of rollout worker actors to create for parallel sampling.
     # Note: Setting the num_workers to 0 will force rollouts to be done in the trainer actor.
+    num_cpus_per_worker: 1
     num_gpus: 0 # number of GPUs to allocate to the trainer process. This can also be fractional (e.g., 0.3 GPUs).
 
 # Environment configuration

--- a/scripts/rice_rllib.yaml
+++ b/scripts/rice_rllib.yaml
@@ -15,7 +15,7 @@ saving:
 
 # Trainer settings
 trainer:
-    num_envs: 20 # number of environment replicas
+    num_envs_per_worker: 1 # number of environment replicas per worker
     rollout_fragment_length: 100 # divide episodes into fragments of this many steps each during rollouts.
     train_batch_size: 2000 # total batch size used for training per iteration (across all the environments)
     num_episodes: 100 # number of episodes to run the training for

--- a/scripts/rice_rllib.yaml
+++ b/scripts/rice_rllib.yaml
@@ -31,6 +31,7 @@ trainer:
 env:
     num_discrete_action_levels: 10 # number of discrete levels for the saving and mitigation actions
     negotiation_on: True # flag to indicate whether negotiation is allowed or not
+    scenario: BasicClub # key that maps to either Rice or and alternate Rice class
 
 # Policy network settings
 policy:

--- a/scripts/train_with_rllib.py
+++ b/scripts/train_with_rllib.py
@@ -199,11 +199,7 @@ def get_rllib_config(config_yaml=None, env_class=None, seed=None):
         "multiagent": multiagent_policies_config,
         "num_workers": trainer_config["num_workers"],
         "num_gpus": trainer_config["num_gpus"],
-        "num_envs_per_worker": (
-            trainer_config["num_envs"] // trainer_config["num_workers"]
-        )
-        if trainer_config["num_workers"] > 0
-        else trainer_config["num_envs"],
+        "num_envs_per_worker": trainer_config["num_envs_per_worker"],
         "train_batch_size": trainer_config["train_batch_size"],
     }
     if seed is not None:

--- a/scripts/train_with_rllib.py
+++ b/scripts/train_with_rllib.py
@@ -199,6 +199,7 @@ def get_rllib_config(config_yaml=None, env_class=None, seed=None):
         "multiagent": multiagent_policies_config,
         "num_workers": trainer_config["num_workers"],
         "num_gpus": trainer_config["num_gpus"],
+        "num_cpus_per_worker": trainer_config["num_cpus_per_worker"],
         "num_envs_per_worker": trainer_config["num_envs_per_worker"],
         "train_batch_size": trainer_config["train_batch_size"],
     }

--- a/scripts/train_with_rllib.py
+++ b/scripts/train_with_rllib.py
@@ -25,11 +25,18 @@ from fixed_paths import PUBLIC_REPO_DIR
 from run_unittests import import_class_from_path
 from opt_helper import save
 from rice import Rice
-
+from scenarios import *
 sys.path.append(PUBLIC_REPO_DIR)
 
 # Set logger level e.g., DEBUG, INFO, WARNING, ERROR.
 logging.getLogger().setLevel(logging.DEBUG)
+
+#scenarios
+SCENARIO_MAPPING = {
+    "default":Rice,
+    "OptimalMitigation":OptimalMitigation,
+    "BasicClub":BasicClub
+}
 
 
 import ray
@@ -138,7 +145,7 @@ class EnvWrapper(MultiAgentEnv):
         if source_dir is None:
             source_dir = PUBLIC_REPO_DIR
         assert isinstance(env_config_copy, dict)
-        self.env = Rice(**env_config_copy)
+        self.env = SCENARIO_MAPPING[env_config["scenario"]](**env_config_copy)
 
         self.action_space = self.env.action_space
 


### PR DESCRIPTION
Updated: the previous one somehow seems buggy: gives inf values during training after merge to GAIA, thus, I revert the merge.
The previous link of PR: https://github.com/mila-iqia/climate-cooperation-competition/pull/31

========================================================
TLDR: added scenario classes that inherit from rice but give the users more control over specific behavior, currently implemented though masking. Also note, scenarios included just mask to a minimum value, for the purpose of environment sampling later it would be best to mask it to an exact value, but the purpose of this PR is more for having the scenarios functionality in the first place.

Note: i had to cherrypick brams changes to get it to work locally

Changes:

added scenarios.py contains modified RICE objects
added scenarios key to config yaml
train_with_rllib.py added dictionary of scenario names that links yaml key to class
Rice.py added scenario as rice argument
cherrypicked requirements / brams changes to config yaml (this is necessary to avoid the error where local_worker has an empty environment)
So far it trains, but only running locally and not at scale, would be good to run on a beefy-o-weefy machine to see if it performs the same as during the competition.