### PR TITLE
made clubs part of config

### DIFF
--- a/rice.py
+++ b/rice.py
@@ -46,6 +46,8 @@ class Rice(gym.Env):
         temperature_calibration="base",
         prescribed_emissions=None,
         pct_reward=False,
+        clubs_enabled = False,
+        club_members = []
     ):
         self.action_space_type = action_space_type
         self.num_discrete_action_levels = num_discrete_action_levels
@@ -66,6 +68,11 @@ class Rice(gym.Env):
         self.prescribed_emissions = prescribed_emissions
         self.pct_reward = pct_reward
         self.global_state = {}
+
+        #clubs
+        self.clubs_enabled = clubs_enabled
+        if self.clubs_enabled:
+            self.club_members = club_members
 
         self.set_dtypes()
 

--- a/scripts/create_submission_zip.py
+++ b/scripts/create_submission_zip.py
@@ -79,8 +79,11 @@ def prepare_submission(results_dir=None):
         if file.endswith(".state_dict")
     ]
     sorted_policy_models = sorted(policy_models, key=os.path.getmtime)
-    # Delete all but the last policy model file
-    for policy_model in sorted_policy_models[:-1]:
+
+    #in the case of multi-model, there will be multiple state dictionaries per model.
+    policy_prefixes = set([model_name.split("/")[-1].split("_")[0]for model_name in sorted_policy_models])
+    # Delete all but the last policy model file of each unique prefix
+    for policy_model in sorted_policy_models[:-len(policy_prefixes)]:
         os.remove(os.path.join(results_dir_copy, policy_model.split("/")[-1]))
 
     shutil.make_archive(submission_file, "zip", results_dir_copy)

--- a/scripts/rice_rllib_discrete.yaml
+++ b/scripts/rice_rllib_discrete.yaml
@@ -37,6 +37,8 @@ env:
     carbon_model: "base"
     temperature_calibration: "base"
     pct_reward: False
+    clubs_enabled: True
+    club_members: [1]
 
 regions:
     num_agents: 3 #can be either {3,7,20,27}
@@ -52,6 +54,7 @@ logging:
 
 # Policy network settings
 policy:
+    multi_model: True #only active if club_enabled also set to True
     regions:
         vf_loss_coeff: 0.1 # loss coefficient schedule for the value function loss
         entropy_coeff_schedule: # loss coefficient schedule for the entropy loss


### PR DESCRIPTION
i got really tired of configuring fixed clubs at the scenario level
so i made it a part of the config, this saves alot of time during the eval as everything is now contained within the submission .zip

As it stands, the clubs don't effect RICE behavior at all, its more that the club is there for scenarios (subclasses) to use it in different ways.

Also added multi-model mode in which club members are assigned to one model and non-club members another. 
